### PR TITLE
Add function definitions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 .idea
 libz3.*
+release

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 libz3.*
 release
+.z3-trace

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,9 +383,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "z3"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05b1c80cd890d936ecafd439e757113a397f5797b12232b29c443256dd02c07b"
+checksum = "9b0fb454561421259678f07d6a9f23b289b8496ebbac3cbe67603e4e99c982ec"
 dependencies = [
  "lazy_static",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,6 +10,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "ascii-canvas"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -36,6 +45,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb031dd78e28731d87d56cc8ffef4a8f36ca26c38fe2de700543e627f8a464a"
 
 [[package]]
+name = "bindgen"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap",
+ "env_logger",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,10 +89,60 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf1de2fe8c75bc145a2f577add951f8134889b4795d47466a54a5c846d691693"
 
 [[package]]
+name = "cc"
+version = "1.0.70"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
+
+[[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clang-sys"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10612c0ec0e0a1ff0e97980647cb058a6e7aedb913d01d009c406b8b7d0b26ee"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
+]
+
+[[package]]
+name = "clap"
+version = "2.33.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37e58ac78573c40708d45522f0d80fa2f01cc4f9b4e2bf749807255454312002"
+dependencies = [
+ "ansi_term",
+ "atty",
+ "bitflags",
+ "strsim",
+ "textwrap",
+ "unicode-width",
+ "vec_map",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb6210b637171dfba4cda12e579ac6dc73f5165ad56133e5d72ef3131f320855"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "crunchy"
@@ -111,6 +193,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fixedbitset"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -128,6 +223,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b919933a397b79c37e33b77bb2aa3dc8eb6e165ad809e58ff75bc7db2e34574"
+
+[[package]]
 name = "hashbrown"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -141,6 +242,12 @@ checksum = "322f4de77956e22ed0e5032c359a0f1273f1f7f0d79bfa3b8ffbc730d7fbcc5c"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "imp"
@@ -210,10 +317,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "12b8adadd720df158f4d70dfe7ccc6adb0472d7c55ca83445f6a5ab3e36f8fb6"
+
+[[package]]
+name = "libloading"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f84d96438c15fcd6c3f244c8fce01d1e2b9c6b5623e9c711dc9286d8fc92d6a"
+dependencies = [
+ "cfg-if",
+ "winapi",
+]
 
 [[package]]
 name = "log"
@@ -235,6 +358,22 @@ name = "new_debug_unreachable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
+
+[[package]]
+name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "petgraph"
@@ -266,6 +405,24 @@ name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f5105d4fdaab20335ca9565e106a5d9b82b6219b5ba735731124ac6711d23d"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "redox_syscall"
@@ -304,10 +461,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61b3909d758bb75c79f23d4736fac9433868679d3ad2ea7a61e3c25cfda9a088"
+
+[[package]]
+name = "shlex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
 
 [[package]]
 name = "siphasher"
@@ -328,6 +497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
+
+[[package]]
 name = "term"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -336,6 +511,24 @@ dependencies = [
  "dirs-next",
  "rustversion",
  "winapi",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -348,16 +541,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "vec_map"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bddf1187be692e79c5ffeab891132dfb0f236ed36a43c7ed39f1165ee20191"
+
+[[package]]
+name = "version_check"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
+
+[[package]]
 name = "wasi"
 version = "0.10.2+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
+
+[[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "winapi"
@@ -376,6 +596,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -383,9 +612,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "z3"
-version = "0.11.0"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b0fb454561421259678f07d6a9f23b289b8496ebbac3cbe67603e4e99c982ec"
+checksum = "d25754b4bf4516a65d0e596ea9c1f0082224bdf20823a37fdd9111fa08d5bf48"
 dependencies = [
  "lazy_static",
  "log",
@@ -394,6 +623,10 @@ dependencies = [
 
 [[package]]
 name = "z3-sys"
-version = "0.6.3"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afa18ba5fbd4933e41ffb440c3fd91f91fe9cdb7310cce3ddfb6648563811de0"
+checksum = "1c82dcbc58be4bf1994c520066cb2bd6c3d36aed0fdc57244f34d277421986a6"
+dependencies = [
+ "bindgen",
+ "cmake",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ lalrpop = "0.19.6"
 [dependencies]
 lalrpop-util = "0.19.6"
 regex = "1"
-z3 = "0.10.0"
+z3 = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,4 +10,4 @@ lalrpop = "0.19.6"
 [dependencies]
 lalrpop-util = "0.19.6"
 regex = "1"
-z3 = "0.11.0"
+z3 = {version="0.11.2", features = ["static-link-z3"]}

--- a/README.md
+++ b/README.md
@@ -69,3 +69,14 @@ while (i # a) do
 
 To make sure no errors happen because of to this, always write these assertions with explicit parentheses like `b and (P)`  resp. `b and (P) and e = Z` for
 while loops in total correctness proofs (see [`examples/divide.imp`](./examples/divide.imp) for an example of a total correctness proof).
+
+### Functions
+You might not be happy with just IMP operators in your pre-/post-conditions, so just like in the course, this tool
+allows you to define your own functions (and offers the built-in `!` factorial function). The syntax for function calls
+should be familiar, but function definitions are a bit odd; at the moment their body must consist of a single expression,
+which may contain a recursive call. Also, the body's expression supports the ternary `? :` operator to provide
+if-then-else control flow.
+
+See [`examples/gcd_partial.imp`](./examples/gcd_partial.imp) for a proof making use of a user-provided function definition,
+and [`examples/factorial_partial`](./examples/factorial_partial.imp) for a proof making use of the built-in factorial `!`.
+Note that the tool is currently unable to verify either of those proofs, it reports `UNKNOWN`.

--- a/examples/exponentiation_total.imp
+++ b/examples/exponentiation_total.imp
@@ -1,0 +1,25 @@
+{x = X and X >= 0}
+|=
+{ x = X and X >= 0 and 1 = 1}
+y := 1
+{ x = X and X >= 0 and y = 1}
+|=
+{ x = X and X >= 0 and y = 1 and 0 = 0}
+z := 0
+{ x = X and X >= 0 and y = 1 and z = 0}
+|=
+{ x = X and X >= 0 and y = 1 and z = 0}
+|=
+{x = X and y = 2 ^ z and z <= x}
+while z < x do
+    {z < x and (x = X and y = 2 ^ z and z <= x) and x - z = V}
+    |=
+    {x = X and y * 2 = 2 ^(z + 1) and z + 1 <= x and (x - (z+1)) < V}
+    y := y * 2
+    {x = X and y = 2 ^(z + 1) and z + 1 <= x and (x - (z+1)) < V}
+    z := z + 1
+    {x = X and y = 2^z and z <= x and (x - z) < V}
+end
+{not z < x and (x = X and y = 2 ^ z and z <= x)}
+|=
+{y = 2^X}

--- a/examples/factorial_partial.imp
+++ b/examples/factorial_partial.imp
@@ -1,0 +1,17 @@
+{ x = N }
+|=
+{ x > 0 -> 1 * x! = N! and N >= x }
+y := 1
+{x > 0 -> y * x! = N! and N >= x}
+while not x = 1 do
+    { not x = 1 and (x > 0 -> y * x! = N! and N >= x)}
+    |=
+    { x - 1 > 0 -> y * x * (x-1)! = N! and N >= x - 1 }
+    y := y * x
+    { x - 1 > 0 -> y * (x-1)! = N! and N >= x - 1 }
+    x := x - 1
+    { x > 0 -> y * x! = N! and N >= x }
+end
+{not not x = 1 and (x > 0 -> y * x! = N! and N >= x) }
+|=
+{y = N! and N > 0}

--- a/examples/gcd_partial.imp
+++ b/examples/gcd_partial.imp
@@ -1,0 +1,37 @@
+gcd(m, n) {
+    (m % n = 0) ? n : gcd(n, m % n)
+}
+
+{x = X and y = Y and X > 0 and Y > 0}
+|=
+{x = X and y = Y and X > 0 and Y > 0 and x = X}
+b := x
+{x = X and y = Y and X > 0 and Y > 0 and b = X}
+|=
+{x = X and y = Y and X > 0 and Y > 0 and b = X and y = Y}
+c := y
+{x = X and y = Y and X > 0 and Y > 0 and b = X and c = Y}
+|=
+{gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y}
+while b # c do
+    { b # c and (gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y) }
+    if b < c then
+        { b < c and (b # c and (gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y)) }
+        |=
+        {gcd(x,y) = gcd(b,c - b) and b > 0 and c - b > 0 and x = X and y = Y}
+        c := c - b
+        { gcd(x, y) = gcd(b, c) and b > 0 and c > 0 and x = X and y = Y}
+    else
+        { not b < c and (b # c and (gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y)) }
+        |=
+        {gcd(x,y) = gcd(b - c,c) and b - c > 0 and c > 0 and x = X and y = Y}
+        b := b - c
+        {gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y}
+    end
+    {gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y}
+end
+{not b # c and (gcd(x,y) = gcd(b,c) and b > 0 and c > 0 and x = X and y = Y)}
+|=
+{b = gcd(X, Y)}
+z := b
+{z = gcd(X, Y)}

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -450,7 +450,7 @@ impl Aexp {
                     Opcode::Sub => z3::ast::Int::sub(ctx, &[&left, &right]),
                     Opcode::Mul => z3::ast::Int::mul(ctx, &[&left, &right]),
                     Opcode::Mod => left.modulo(&right),
-                    Opcode::Pow => left.power(&right),
+                    Opcode::Pow => left.power(&right).to_real().to_int(),
                 }
             },
             Aexp::FuncApp(fname, args) => {

--- a/src/expression.rs
+++ b/src/expression.rs
@@ -1,6 +1,14 @@
 use super::ast::*;
 use crate::state::State;
 
+fn unsupported_op(op: &Opcode) -> ! {
+    panic!("Operation {:?} is not valid IMP! You may only use {:?} in pre-/post-conditions.", op, op)
+}
+
+fn unsupported_exp(exp: &Aexp) -> ! {
+    panic!("{:?} is not valid IMP. You may only use this expression in pre-/post-conditions.", exp)
+}
+
 pub fn arithmetic_eval(aexp: &Box<Aexp>, state: &State) -> i64 {
     match aexp.as_ref() {
         Aexp::Numeral(num) => *num,
@@ -8,6 +16,8 @@ pub fn arithmetic_eval(aexp: &Box<Aexp>, state: &State) -> i64 {
         Aexp::Op(left, Opcode::Add, right) => arithmetic_eval(left, state) + arithmetic_eval(right, state),
         Aexp::Op(left, Opcode::Sub, right) => arithmetic_eval(left, state) - arithmetic_eval(right, state),
         Aexp::Op(left, Opcode::Mul, right) => arithmetic_eval(left, state) * arithmetic_eval(right, state),
+        Aexp::Op(_, op, _) => unsupported_op(op),
+        exp => unsupported_exp(exp),
     }
 }
 

--- a/src/imp.lalrpop
+++ b/src/imp.lalrpop
@@ -4,6 +4,29 @@ use crate::ast::*;
 
 grammar;
 
+pub AxProgram: (Vec<ImpFuncDef>, AxBlock) = {
+    <funcs:(FuncDef*)> <prog:AxBlock> => (funcs, prog),
+}
+
+FuncDef: ImpFuncDef = {
+    <name:Var> "(" <args:Params> ")" "{"
+        <body:Aexp>
+    "}" => ImpFuncDef {name:name, args:args, body:*body},
+
+}
+
+Params: Vec<Var> = {
+    => vec![],
+    <param:Var> <mut params:ParamsHelper> => {
+        params.insert(0, param);
+        params
+    }
+}
+
+ParamsHelper: Vec<Var> = {
+    <("," <Var>)*> => <>,
+}
+
 pub AssertionChain: AssertionChain = {
     "{" <first:Bexp> "}" <rem:(Entailment "{" <Bexp> "}")*> => AssertionChain::new(first, rem)
 }
@@ -78,7 +101,7 @@ Bexp1: Box<Bexp> = {
 }
 
 Bexp2: Box<Bexp> = {
-    "not" <Bexp3> => Box::new(Bexp::Not(<>)),
+    "not" <Bexp2> => Box::new(Bexp::Not(<>)),
     Bexp3
 }
 
@@ -110,23 +133,47 @@ Bexp3Op: Ropcode = {
 
 
 pub Aexp = {
+    "(" <Bexp> ")" "?" <Aexp> ":" <Aexp> => Box::new(Aexp::Ite(<>)),
     Aexp0
 }
 
 Aexp0: Box<Aexp> = {
     Aexp0 Aexp0Op Aexp1 => Box::new(Aexp::Op(<>)),
-    Aexp1
+    Aexp1,
 }
 
 Aexp1: Box<Aexp> = {
     Aexp1 Aexp1Op Aexp2 => Box::new(Aexp::Op(<>)),
-    Aexp2
+    Aexp2,
 }
 
 Aexp2: Box<Aexp> = {
+    Aexp2 Aexp2Op Aexp3 => Box::new(Aexp::Op(<>)),
+    Aexp3,
+}
+
+Aexp3: Box<Aexp> = {
+    <Aexp3> "!" => Box::new(Aexp::FuncApp("factorial".to_owned(), vec![*<>])),
+    Aexp4,
+}
+
+Aexp4: Box<Aexp> = {
     Numeral => Box::new(Aexp::Numeral(<>)),
     Var => Box::new(Aexp::Var(<>)),
-    "(" <Aexp> ")"
+    <name:Var> "(" <args:Args> ")" => Box::new(Aexp::FuncApp(name, args)),
+    "(" <Aexp> ")",
+}
+
+Args: Vec<Aexp> = {
+    => vec![],
+    <arg:Aexp> <mut args:ArgsHelper> => {
+        args.insert(0, *arg);
+        args
+    }
+}
+
+ArgsHelper: Vec<Aexp> = {
+    <("," <Aexp>)*> => <>.into_iter().map(|arg| *arg).collect(),
 }
 
 Var: String = r"[A-Za-z][A-Za-z0-9]*" => (<>).to_owned();
@@ -140,5 +187,10 @@ Aexp0Op: Opcode = {
 
 Aexp1Op: Opcode = {
     "*" => Opcode::Mul,
+    "%" => Opcode::Mod,
+}
+
+Aexp2Op: Opcode = {
+    "^" => Opcode::Pow,
 }
 


### PR DESCRIPTION
This adds support for function definitions that may help in expressing pre-/post-conditions for axiomatic semantics. They are only allowed there, not in the IMP program itself. As they are directly translated to Z3 define-fun-rec's, only the simplest functions will help check a proof at the moment. 

See the README change for more information.